### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.2.1...v0.3.0) - 2025-07-14
+
+### Other
+
+- [**breaking**] implemented `BinReadExt`, `BinWriteExt`, and `TryFrom<&[u8]>`
+- [**breaking**] moved existing types into modules `m64` and `shared`
+
 ## [0.2.1](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.2.0...v0.2.1) - 2025-07-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "m64-movie"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bilge",
  "binrw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "m64-movie"
 authors = ["Phillip Smith <TimeTravelPenguin@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 include = ["src/lib.rs", "LICENSE", "README.md"]
 description = "A library for reading and writing M64 movie files."


### PR DESCRIPTION



## 🤖 New release

* `m64-movie`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `m64-movie` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct m64_movie::Reserved, previously in file /tmp/.tmpPCF1Mi/m64-movie/src/lib.rs:224
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.2.1...v0.3.0) - 2025-07-14

### Other

- [**breaking**] implemented `BinReadExt`, `BinWriteExt`, and `TryFrom<&[u8]>`
- [**breaking**] moved existing types into modules `m64` and `shared`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).