### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tidied up exports
 - updated README
 - updated docstrings
-- updated docstrings
-- corrected links
-- [**breaking**] improved public lib api
-- reordered code
 - [**breaking**] moved `impl`s into respective modules
 - [**breaking**] moved `m64::ControllerButton` to `movie::ControllerButton`
 - [**breaking**] moved `m64::Movie` to `raw::m64:RawMovie`
@@ -36,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(docs)* corrected incorrect docs
+- _(docs)_ corrected incorrect docs
 
 ## [0.3.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.2.1...v0.3.0) - 2025-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.3.1...v0.4.0) - 2025-07-17
+
+### Added
+
+- [**breaking**] replaced `ExtendedFlags` and `ExtendedData` with enum variant
+- [**breaking**] refactored `EncodedFixedStr<const N: usize>`
+- added `Movie::controller_inputs_stream()`
+- added `Movie` for a more idiomatic Rust-style use
+- added `from_utf8_str` and `from_ascii_str`
+- implemented `Default` for `Reserved`
+- added `shared::FixedStr` and `shared::EncodedFixedStr`
+
+### Other
+
+- tidied up exports
+- updated README
+- updated docstrings
+- updated docstrings
+- corrected links
+- [**breaking**] improved public lib api
+- reordered code
+- [**breaking**] moved `impl`s into respective modules
+- [**breaking**] moved `m64::ControllerButton` to `movie::ControllerButton`
+- [**breaking**] moved `m64::Movie` to `raw::m64:RawMovie`
+
 ## [0.3.1](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.3.0...v0.3.1) - 2025-07-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "m64-movie"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bilge",
  "binrw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "m64-movie"
 authors = ["Phillip Smith <TimeTravelPenguin@gmail.com>"]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 include = ["src/**/*.rs", "doc/**/*.md", "LICENSE", "README.md"]
 description = "A library for reading and writing M64 movie files."


### PR DESCRIPTION



## 🤖 New release

* `m64-movie`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `m64-movie` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Movie.metadata in /tmp/.tmpjpT1SN/m64-movie/src/parsed/m64.rs:140
  field Movie.game_info in /tmp/.tmpjpT1SN/m64-movie/src/parsed/m64.rs:142
  field Movie.plugin_info in /tmp/.tmpjpT1SN/m64-movie/src/parsed/m64.rs:144
  field Movie.recording_info in /tmp/.tmpjpT1SN/m64-movie/src/parsed/m64.rs:146

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum m64_movie::m64::MovieStartType, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:268
  enum m64_movie::MovieStartType, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:268
  enum m64_movie::m64::ControllerButton, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:291

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod m64_movie::m64, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct m64_movie::m64::ControllerFlags, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:198
  struct m64_movie::ControllerFlags, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:198
  struct m64_movie::m64::Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:63
  struct m64_movie::m64::ExtendedFlags, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:188
  struct m64_movie::ExtendedFlags, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:188
  struct m64_movie::m64::ControllerState, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:327
  struct m64_movie::ControllerState, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:327
  struct m64_movie::m64::ExtendedData, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:244
  struct m64_movie::ExtendedData, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:244

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field version of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:65
  field uid of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:68
  field vertical_interrupts of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:71
  field rerecord_count of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:74
  field vis_per_second of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:77
  field controller_count of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:80
  field extended_version of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:84
  field extended_flags of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:87
  field controller_input_samples of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:90
  field start_type of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:93
  field reserved01 of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:96
  field controller_flags of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:99
  field extended_data of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:102
  field reserved02 of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:105
  field rom_name of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:113
  field rom_crc32 of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:117
  field rom_country of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:121
  field reserved03 of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:124
  field video_plugin of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:132
  field sound_plugin of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:140
  field input_plugin of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:148
  field rsp_plugin of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:156
  field author_name of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:160
  field description of struct Movie, previously in file /tmp/.tmpMXD0Gu/m64-movie/src/m64.rs:164

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type m64_movie::BinReadExt::Error in file /tmp/.tmpjpT1SN/m64-movie/src/lib.rs:52
  trait associated type m64_movie::BinWriteExt::Error in file /tmp/.tmpjpT1SN/m64-movie/src/lib.rs:61
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.3.1...v0.4.0) - 2025-07-17

### Added

- [**breaking**] replaced `ExtendedFlags` and `ExtendedData` with enum variant
- [**breaking**] refactored `EncodedFixedStr<const N: usize>`
- added `Movie::controller_inputs_stream()`
- added `Movie` for a more idiomatic Rust-style use
- added `from_utf8_str` and `from_ascii_str`
- implemented `Default` for `Reserved`
- added `shared::FixedStr` and `shared::EncodedFixedStr`

### Other

- tidied up exports
- updated README
- updated docstrings
- updated docstrings
- corrected links
- [**breaking**] improved public lib api
- reordered code
- [**breaking**] moved `impl`s into respective modules
- [**breaking**] moved `m64::ControllerButton` to `movie::ControllerButton`
- [**breaking**] moved `m64::Movie` to `raw::m64:RawMovie`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).