### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- revert rename
 - added missing docs
 
 ## [0.4.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.3.1...v0.4.0) - 2025-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.4.0...v0.4.1) - 2025-07-17
+
+### Other
+
+- revert rename
+- added missing docs
+
 ## [0.4.0](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.3.1...v0.4.0) - 2025-07-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "m64-movie"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bilge",
  "binrw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "m64-movie"
 authors = ["Phillip Smith <TimeTravelPenguin@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 include = ["src/**/*.rs", "doc/**/*.md", "LICENSE", "README.md"]
 description = "A library for reading and writing M64 movie files."


### PR DESCRIPTION



## 🤖 New release

* `m64-movie`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/TimeTravelPenguin/m64-movie/compare/v0.4.0...v0.4.1) - 2025-07-17

### Other

- revert rename
- added missing docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).